### PR TITLE
add page strategy and improve function overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Paginate
 
-Idoimatic Typescript API for iterating over any paginated data.
+Idiomatic TypeScript API for iterating over any paginated data.
 
 ## Motivation
 
 When working with paginated APIs or data sources, developers often need to:
 
-1. Handle both offset-based and cursor-based pagination
+1. Handle offset-based, page-based, and cursor-based pagination
 2. Deal with errors gracefully without breaking the entire data fetch
 3. Repeat boilerplate pagination logic
 4. Manage state between pagination requests
+5. Get type safety based on pagination strategy
 
-This library solves these problems by providing a simple async iterator that handles all the complexity of pagination while giving you complete control over error handling.
+This library solves these problems by providing a simple async iterator that handles all the complexity of pagination while giving you complete control over error handling and full TypeScript type safety.
 
 ## Installation
 
@@ -25,10 +26,10 @@ pnpm add @pushpress/paginate
 
 ## Usage
 
-### Basic Offset-based Pagination
+### Basic Offset-based Pagination (0-indexed)
 
 ```typescript
-import { paginate } from "paginate";
+import { paginate } from "@pushpress/paginate";
 
 // Create an async iterator over your paginated data
 const iterator = paginate(
@@ -51,6 +52,35 @@ const iterator = paginate(
 );
 
 // Iterate over all items
+for await (const item of iterator) {
+  console.log(item);
+}
+```
+
+### Page-based Pagination (1-indexed)
+
+```typescript
+// Perfect for APIs that use 1-indexed page numbers
+const iterator = paginate(
+  async ({ limit, page }) => {
+    const response = await fetch(`/api/items?limit=${limit}&page=${page}`);
+    const data = await response.json();
+
+    return {
+      items: data.items,
+      pageInfo: {
+        hasNextPage: data.hasMore,
+      },
+    };
+  },
+  {
+    strategy: "page",
+    limit: 10,
+    initialPage: 1, // Start from page 1
+    errorPolicy: { type: "throw" },
+  },
+);
+
 for await (const item of iterator) {
   console.log(item);
 }
@@ -89,9 +119,64 @@ const iterator = paginate(
 );
 
 for await (const item of iterator) {
-  // proces item
+  // process item
   await processItem(item);
 }
+```
+
+## Type Safety
+
+The library provides excellent TypeScript support with strategy-specific callback types and function overloads:
+
+### Strategy-Specific Callbacks
+
+Each pagination strategy has its own callback type that only receives the relevant parameters:
+
+```typescript
+// Offset strategy - only receives offset parameter
+const offsetPagination = paginate(
+  async ({ limit, offset }) => { /* only offset available */ },
+  { strategy: "offset", limit: 10, errorPolicy: { type: "throw" } }
+);
+
+// Page strategy - only receives page parameter  
+const pagePagination = paginate(
+  async ({ limit, page }) => { /* only page available */ },
+  { strategy: "page", limit: 10, errorPolicy: { type: "throw" } }
+);
+
+// Cursor strategy - only receives cursor parameter
+const cursorPagination = paginate(
+  async ({ limit, cursor }) => { /* only cursor available */ },
+  { strategy: "cursor", limit: 10, errorPolicy: { type: "throw" } }
+);
+```
+
+### Function Overloads
+
+TypeScript will provide autocomplete and type checking based on your chosen strategy:
+
+```typescript
+// TypeScript knows this callback only receives offset
+const offsetCallback: OffsetPaginationCallback<User> = async ({ limit, offset }) => {
+  // offset is typed as number
+  // page and cursor are not available
+  return await fetchUsers({ limit, offset });
+};
+
+// TypeScript knows this callback only receives page
+const pageCallback: PagePaginationCallback<User> = async ({ limit, page }) => {
+  // page is typed as number
+  // offset and cursor are not available
+  return await fetchUsers({ limit, page });
+};
+
+// TypeScript knows this callback only receives cursor
+const cursorCallback: CursorPaginationCallback<User> = async ({ limit, cursor }) => {
+  // cursor is typed as string | null
+  // offset and page are not available
+  return await fetchUsers({ limit, cursor });
+};
 ```
 
 ## Fluent Interface
@@ -269,44 +354,86 @@ Creates a `FluentAsyncIterable<T>` that yields items from a paginated data sourc
 
 #### Callback Parameters
 
+The library provides strategy-specific callback types for better type safety:
+
 ```typescript
+// Offset-based pagination callback
+type OffsetPaginationCallback<T> = (params: {
+  limit: number;
+  offset: number;
+}) => Promise<PaginatedResult<T>>;
+
+// Page-based pagination callback (1-indexed)
+type PagePaginationCallback<T> = (params: {
+  limit: number;
+  page: number;
+}) => Promise<PaginatedResult<T>>;
+
+// Cursor-based pagination callback
+type CursorPaginationCallback<T> = (params: {
+  limit: number;
+  cursor: string | null;
+}) => Promise<PaginatedResult<T>>;
+
+// Legacy callback type for backward compatibility
 type PaginationCallback<T> = (params: {
   limit: number;
   offset?: number;
+  page?: number;
   cursor?: string | null;
-}) => Promise<{
+}) => Promise<PaginatedResult<T>>;
+
+type PaginatedResult<T> = {
   items: T[];
   pageInfo: {
     hasNextPage: boolean;
     nextCursor?: string | null;
   };
-}>;
+};
 ```
 
 #### Options
 
 ```typescript
-type PaginationOptions = {
-  strategy: "offset" | "cursor";
+type PaginationOptions = 
+  | OffsetPaginationOptions
+  | PagePaginationOptions  
+  | CursorPaginationOptions;
+
+type OffsetPaginationOptions = {
+  strategy: "offset";
   limit: number;
-  initialOffset?: number; // For offset-based pagination
-  initialCursor?: string | null; // For cursor-based pagination
-  logger?: Logger; // Optional logger interface
+  initialOffset?: number;
   errorPolicy: ErrorPolicy;
+  hooks?: PaginationHooks;
+};
+
+type PagePaginationOptions = {
+  strategy: "page";
+  limit: number;
+  initialPage?: number; // 1-indexed, defaults to 1
+  errorPolicy: ErrorPolicy;
+  hooks?: PaginationHooks;
+};
+
+type CursorPaginationOptions = {
+  strategy: "cursor";
+  limit: number;
+  initialCursor?: string | null;
+  errorPolicy: ErrorPolicy;
+  hooks?: PaginationHooks;
 };
 
 type ErrorPolicy =
   | {
       type: "continue";
       maxErrorCount: number;
-      onError?: (error: unknown) => void | Promise<void>;
     }
   | {
       type: "throw";
     }
   | {
       type: "break";
-      onError?: (error: unknown) => void | Promise<void>;
     }
   | {
       type: "custom";
@@ -315,6 +442,20 @@ type ErrorPolicy =
         context: { consecutiveErrors: number },
       ) => boolean | Promise<boolean>;
     };
+
+type PaginationHooks = {
+  onPage?: (options: {
+    offset?: number;
+    page?: number;
+    cursor?: string | number | null;
+  }) => void | Promise<void>;
+  onReturn?: () => void | Promise<void>;
+  onError?: (error: unknown) => void | Promise<void>;
+  onMaxConsecutiveErrors?: (
+    error: unknown,
+    context: { errors: number },
+  ) => void | Promise<void>;
+};
 ```
 
 ## Error Handling Strategies
@@ -402,11 +543,96 @@ It must return (or resolve to):
 - `true`: Continue pagination
 - `false`: Stop pagination
 
+## Hooks System
+
+The library provides a comprehensive hooks system for monitoring and debugging pagination:
+
+### Available Hooks
+
+```typescript
+const iterator = paginate(callback, {
+  strategy: "offset",
+  limit: 10,
+  errorPolicy: { type: "throw" },
+  hooks: {
+    onPage: async ({ offset, page, cursor }) => {
+      console.log(`Fetching page: offset=${offset}, page=${page}, cursor=${cursor}`);
+    },
+    onError: async (error) => {
+      console.error("Pagination error:", error);
+    },
+    onMaxConsecutiveErrors: async (error, { errors }) => {
+      console.error(`Max consecutive errors reached: ${errors}`, error);
+    },
+    onReturn: async () => {
+      console.log("Pagination completed");
+    },
+  },
+});
+```
+
+### Hook Usage Examples
+
+**Progress Monitoring:**
+```typescript
+const iterator = paginate(callback, {
+  strategy: "page",
+  limit: 50,
+  errorPolicy: { type: "continue", maxErrorCount: 3 },
+  hooks: {
+    onPage: ({ page }) => {
+      console.log(`Processing page ${page}...`);
+    },
+    onReturn: () => {
+      console.log("All pages processed successfully!");
+    },
+  },
+});
+```
+
+**Error Tracking:**
+```typescript
+const iterator = paginate(callback, {
+  strategy: "cursor",
+  limit: 25,
+  errorPolicy: { type: "continue", maxErrorCount: 5 },
+  hooks: {
+    onError: async (error) => {
+      await logError(error);
+    },
+    onMaxConsecutiveErrors: async (error, { errors }) => {
+      await alertMonitoring(`Pagination failed after ${errors} consecutive errors`);
+    },
+  },
+});
+```
+
+**Resource Cleanup:**
+```typescript
+let connectionCount = 0;
+
+const iterator = paginate(callback, {
+  strategy: "offset",
+  limit: 10,
+  errorPolicy: { type: "throw" },
+  hooks: {
+    onPage: () => {
+      connectionCount++;
+    },
+    onReturn: () => {
+      console.log(`Total connections used: ${connectionCount}`);
+      connectionCount = 0;
+    },
+  },
+});
+```
+
 ## Best Practices
 
 1. **Choose the right pagination strategy**:
-   - Use offset-based for small to medium datasets with random access needs
-   - Use cursor-based for large datasets or real-time data
+   - Use **offset-based** for small to medium datasets with random access needs (0-indexed)
+   - Use **page-based** for APIs that use 1-indexed page numbers (common in REST APIs)
+   - Use **cursor-based** for large datasets or real-time data
 
 2. **Set appropriate limits**: Balance network requests with memory usage
 
@@ -416,6 +642,13 @@ It must return (or resolve to):
    - Use "throw" for critical data that must be complete and when errors are expected
    - Use "custom" for complex error handling requirements
 
-4. **Use error callbacks effectively**:
-   - Log errors for monitoring and debugging
-   - Clean up resources when pagination stops
+4. **Use hooks for monitoring and debugging**:
+   - Use `onPage` to log pagination progress
+   - Use `onError` to log errors for monitoring
+   - Use `onMaxConsecutiveErrors` to detect when pagination is struggling
+   - Use `onReturn` for cleanup when pagination completes
+
+5. **Leverage TypeScript type safety**:
+   - Use strategy-specific callback types for better autocomplete
+   - Let TypeScript catch mismatched strategy/callback combinations
+   - Use function overloads for compile-time validation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pushpress/paginate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
# Add page strategy and improve function overload

This PR adds support for page-based pagination (1-indexed) alongside the existing offset-based (0-indexed) and cursor-based pagination strategies. It also improves TypeScript type safety with strategy-specific callback types and function overloads.

Key changes:
- Added page-based pagination strategy for APIs that use 1-indexed page numbers
- Implemented strategy-specific callback types for better type safety
- Added function overloads for compile-time validation
- Enhanced hooks system with additional context parameters
- Fixed a typo in "Idiomatic" in the README
- Updated documentation with examples for all pagination strategies
- Added comprehensive tests for the new page strategy

## 0.3.0